### PR TITLE
Depend on `railties` & `activesupport`, rather than all of `rails`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,37 +2,13 @@ PATH
   remote: .
   specs:
     bigrails-redis (0.7.0)
-      rails (>= 6)
+      activesupport (>= 6)
+      railties (>= 6)
       redis (>= 4)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    actioncable (7.0.2.3)
-      actionpack (= 7.0.2.3)
-      activesupport (= 7.0.2.3)
-      nio4r (~> 2.0)
-      websocket-driver (>= 0.6.1)
-    actionmailbox (7.0.2.3)
-      actionpack (= 7.0.2.3)
-      activejob (= 7.0.2.3)
-      activerecord (= 7.0.2.3)
-      activestorage (= 7.0.2.3)
-      activesupport (= 7.0.2.3)
-      mail (>= 2.7.1)
-      net-imap
-      net-pop
-      net-smtp
-    actionmailer (7.0.2.3)
-      actionpack (= 7.0.2.3)
-      actionview (= 7.0.2.3)
-      activejob (= 7.0.2.3)
-      activesupport (= 7.0.2.3)
-      mail (~> 2.5, >= 2.5.4)
-      net-imap
-      net-pop
-      net-smtp
-      rails-dom-testing (~> 2.0)
     actionpack (7.0.2.3)
       actionview (= 7.0.2.3)
       activesupport (= 7.0.2.3)
@@ -40,34 +16,12 @@ GEM
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actiontext (7.0.2.3)
-      actionpack (= 7.0.2.3)
-      activerecord (= 7.0.2.3)
-      activestorage (= 7.0.2.3)
-      activesupport (= 7.0.2.3)
-      globalid (>= 0.6.0)
-      nokogiri (>= 1.8.5)
     actionview (7.0.2.3)
       activesupport (= 7.0.2.3)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    activejob (7.0.2.3)
-      activesupport (= 7.0.2.3)
-      globalid (>= 0.3.6)
-    activemodel (7.0.2.3)
-      activesupport (= 7.0.2.3)
-    activerecord (7.0.2.3)
-      activemodel (= 7.0.2.3)
-      activesupport (= 7.0.2.3)
-    activestorage (7.0.2.3)
-      actionpack (= 7.0.2.3)
-      activejob (= 7.0.2.3)
-      activerecord (= 7.0.2.3)
-      activesupport (= 7.0.2.3)
-      marcel (~> 1.0)
-      mini_mime (>= 1.1.0)
     activesupport (7.0.2.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
@@ -79,39 +33,19 @@ GEM
     connection_pool (2.2.5)
     crass (1.0.6)
     diff-lcs (1.5.0)
-    digest (3.1.0)
     erubi (1.10.0)
     fakeredis (0.8.0)
       redis (~> 4.1)
-    globalid (1.0.0)
-      activesupport (>= 5.0)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     loofah (2.16.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.1)
-      mini_mime (>= 0.1.1)
-    marcel (1.0.2)
     method_source (1.0.0)
-    mini_mime (1.1.2)
     minitest (5.15.0)
-    net-imap (0.2.3)
-      digest
-      net-protocol
-      strscan
-    net-pop (0.1.1)
-      digest
-      net-protocol
-      timeout
-    net-protocol (0.1.3)
-      timeout
-    net-smtp (0.3.1)
-      digest
-      net-protocol
-      timeout
-    nio4r (2.5.8)
     nokogiri (1.13.4-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.13.4-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.4-x86_64-linux)
       racc (~> 1.4)
@@ -122,20 +56,6 @@ GEM
     rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
-    rails (7.0.2.3)
-      actioncable (= 7.0.2.3)
-      actionmailbox (= 7.0.2.3)
-      actionmailer (= 7.0.2.3)
-      actionpack (= 7.0.2.3)
-      actiontext (= 7.0.2.3)
-      actionview (= 7.0.2.3)
-      activejob (= 7.0.2.3)
-      activemodel (= 7.0.2.3)
-      activerecord (= 7.0.2.3)
-      activestorage (= 7.0.2.3)
-      activesupport (= 7.0.2.3)
-      bundler (>= 1.15.0)
-      railties (= 7.0.2.3)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -184,19 +104,15 @@ GEM
     standard (1.10.0)
       rubocop (= 1.27.0)
       rubocop-performance (= 1.13.3)
-    strscan (3.0.1)
     thor (1.2.1)
-    timeout (0.2.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
-    websocket-driver (0.7.5)
-      websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.5)
     zeitwerk (2.5.4)
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/bigrails-redis.gemspec
+++ b/bigrails-redis.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
 
-  spec.add_dependency "rails", ">= 6"
+  spec.add_dependency "railties", ">= 6"
+  spec.add_dependency "activesupport", ">= 6"
   spec.add_dependency "redis", ">= 4"
 end


### PR DESCRIPTION
Update `bigrails-redis.gemspec` to depend more specifically on `railties` and `activesupport`, rather than the top-level `rails` gem.

At Buildkite our monolith specifies individual Rails components (most of them, but not all) as dependencies, and so doesn't currently have `rails` as a dependency. We're only experimenting with `bigrails-redis` at this point, but would be much more likely to use it if it didn't bring in more parts of Rails :)

I believe `bigrails-redis` only uses `ActiveSupport::Autoload`'s `autoload` method and `Rails::Railtie`'s `config.before_configuration`. It would be possible to only depend on `railties` which as `activesupport` as a transient dependency, but since we're calling ActiveSupport directly, it's probably best to explicitly depend on it.