### PR TITLE
Add AGENTS.md and CLAUDE.md for AI coding agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,3 @@
-# AGENTS.md
-
 This file provides guidance to AI coding agents when working with code in this repository.
 
 ## What this project is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+This file provides guidance to AI coding agents when working with code in this repository.
+
+## What this project is
+
+`bigrails-redis` is a Redis connection manager for Rails applications that need to manage multiple named Redis connections. It supports connection pooling via [connection_pool](https://github.com/mperham/connection_pool).
+
+## Commands
+
+```bash
+bundle install
+
+# Run all tests (RSpec)
+bundle exec rspec
+
+# Run a single spec file
+bundle exec rspec spec/path/to/spec.rb
+
+# Lint (uses StandardRB, not RuboCop)
+bundle exec standardrb
+bundle exec standardrb --fix  # auto-correct
+```
+
+## Architecture
+
+- `lib/bigrails/redis.rb` — entry point; provides `BigRails::Redis` configuration DSL
+- `lib/bigrails/redis/` — connection registry, per-connection config objects, and Rails railtie for auto-configuration from `config/redis.rb`
+- `spec/` — RSpec tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary

- Adds `AGENTS.md` with codebase guidance for AI coding agents (commands, architecture)
- Adds `CLAUDE.md` containing just `@AGENTS.md`, following the [Claude Code best practice](https://code.claude.com/docs/en/claude-code-on-the-web#best-practices) of sharing a single instruction file across agents

This makes the same guidance available to Claude Code (via `CLAUDE.md` import) and other agents like Codex that look for `AGENTS.md`.