### PR TITLE
Remove ostruct as a runtime dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     bigrails-redis (0.7.2)
       activesupport (>= 6)
-      ostruct
       railties (>= 6)
       redis (>= 4)
 
@@ -79,7 +78,6 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.5-x86_64-linux)
       racc (~> 1.4)
-    ostruct (0.6.3)
     parallel (2.1.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)

--- a/bigrails-redis.gemspec
+++ b/bigrails-redis.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
 
   spec.add_dependency "activesupport", ">= 6"
-  spec.add_dependency "ostruct"
   spec.add_dependency "railties", ">= 6"
   spec.add_dependency "redis", ">= 4"
 end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -1,17 +1,16 @@
 # frozen_string_literal: true
 
 require "pathname"
-require "ostruct"
 
 module Spec
   module Support
     module Fixtures
       def load_config(type)
-        allow(Rails).to receive(:application).and_return(
-          OpenStruct.new(paths: {
-            "config" => [Pathname.new("spec/fixtures/#{type}").expand_path]
-          })
-        )
+        paths = {
+          "config" => [Pathname.new("spec/fixtures/#{type}").expand_path]
+        }
+        application = double("Rails.application", paths: paths)
+        allow(Rails).to receive(:application).and_return(application)
       end
     end
   end


### PR DESCRIPTION
## Summary

Removes `ostruct` as a runtime dependency. It was only used in a single spec helper (`spec/support/fixtures.rb`) to mock `Rails.application`.

## Changes

- **`bigrails-redis.gemspec`** — dropped `spec.add_dependency "ostruct"`.
- **`spec/support/fixtures.rb`** — replaced the `OpenStruct.new(paths: {...})` mock of `Rails.application` with an RSpec `double`, and removed `require "ostruct"`. The only surface the code exercises is `Rails.application.paths["config"]`, which the double satisfies exactly.
- **`Gemfile.lock`** — `ostruct` removed via `bundle install`.

## Verification

- `bundle exec rspec` — all 10 examples pass
- `bundle exec standardrb` — clean
- `ostruct` no longer appears anywhere in the repo
