### PR TITLE
Replace abandoned fakeredis with real redis, upgrade redis-rb to 5.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,16 @@ jobs:
     env:
       BUNDLE_GEMFILE: Gemfile
     name: "Test and lint: Ruby ${{ matrix.ruby }}"
+    services:
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby }}

--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,4 @@ gemspec
 gem "rake"
 gem "rspec"
 gem "standard"
-gem "fakeredis"
 gem "connection_pool"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,8 +49,6 @@ GEM
     diff-lcs (1.6.2)
     drb (2.2.3)
     erubi (1.12.0)
-    fakeredis (0.9.2)
-      redis (~> 4.8)
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     io-console (0.7.2)
@@ -116,7 +114,10 @@ GEM
     rake (13.4.2)
     rdoc (6.6.3.1)
       psych (>= 4.0.0)
-    redis (4.8.1)
+    redis (5.4.1)
+      redis-client (>= 0.22.0)
+    redis-client (0.30.0)
+      connection_pool
     regexp_parser (2.12.0)
     reline (0.5.7)
       io-console (~> 0.5)
@@ -189,7 +190,6 @@ PLATFORMS
 DEPENDENCIES
   bigrails-redis!
   connection_pool
-  fakeredis
   rake
   rspec
   standard

--- a/spec/support/fakeredis.rb
+++ b/spec/support/fakeredis.rb
@@ -1,1 +1,0 @@
-require "fakeredis/rspec"


### PR DESCRIPTION
## What & why

`fakeredis` is unmaintained — its last release (`0.9.2`, May 2023) hard-pins `redis ~> 4.8`, which is why every Dependabot bump (including #19) left `redis` stuck at `4.8.1` while it moved everything else. There is no fakeredis release that supports redis-rb 5, so this replaces it rather than upgrading it.

The specs never exercised fakeredis's in-memory data store — they only assert connection types and call `verify!`/`quit`. So this switches the test suite to a real redis server, which is what the gem actually ships against.

## Changes

- Remove `fakeredis` from the `Gemfile` and delete the `spec/support/fakeredis.rb` global stub
- Relock: `redis 4.8.1 → 5.4.1` (pulls in `redis-client`)
- Add a `redis` service to the CI `test_and_lint` job — fakeredis was previously the only reason specs passed without a server

## Notes

- The gemspec still declares `redis ">= 4"`, so downstream apps on redis 4 are not forced to upgrade — this only advances the dev/test lock.
- Specs required no rewrite: redis-rb 5 connects lazily, so type assertions and `verify!`/`quit` work against the live server.

## Verification

- `bundle exec rake` → 10 examples, 0 failures (run against a local redis)
- `bundle exec standardrb` → clean
