### PR TITLE
Add explicit GITHUB_TOKEN permissions to workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,5 +8,7 @@ on:
 
 jobs:
   call-workflow-from-shared-config:
+    permissions:
+      contents: write
     uses: rubyatscale/shared-config/.github/workflows/cd.yml@main
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test_and_lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,4 +5,7 @@ on:
     - cron: '0 0 * * *'
 jobs:
   call-workflow-from-shared-config:
+    permissions:
+      issues: write
+      pull-requests: write
     uses: rubyatscale/shared-config/.github/workflows/stale.yml@main

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -6,4 +6,6 @@ on:
       - opened
 jobs:
   call-workflow-from-shared-config:
+    permissions:
+      issues: write
     uses: rubyatscale/shared-config/.github/workflows/triage.yml@main


### PR DESCRIPTION
Resolves the CodeQL actions/missing-workflow-permissions alerts (#1, #2,
#4, #5, #6) by giving every job an effective permissions block.

- ci.yml: workflow-level `contents: read`. Both jobs are covered by it.
  test_and_lint only checks out the repo, installs Ruby and runs
  `bundle exec rake`; notify_on_failure only posts to a Slack incoming
  webhook and needs no token scope at all, so the inherited read grant
  is already more than it uses.
- cd.yml: `contents: write` on the caller job. shared-config's cd.yml
  runs discourse/publish-rubygems-action (`rake release`, which does a
  raw `git push` of the version tag) and then `gh release create`.
  Anything less breaks the gem release.
- stale.yml: `issues: write` + `pull-requests: write`. shared-config's
  stale.yml runs actions/stale, which comments on and closes both stale
  issues and stale PRs.
- triage.yml: `issues: write`. shared-config's triage.yml runs
  `gh issue edit --add-label triage`, and its own job already declares
  the same scope.

Caller permissions are the ceiling for a reusable workflow, so each
caller grants exactly what the called workflow declares/needs and
nothing more. codeql.yml already had a correct block and is untouched.


### Alerts resolved

- [#6](https://github.com/rubyatscale/bigrails-redis/security/code-scanning/6) `actions/missing-workflow-permissions` (medium) — `.github/workflows/ci.yml:11`
- [#5](https://github.com/rubyatscale/bigrails-redis/security/code-scanning/5) `actions/missing-workflow-permissions` (medium) — `.github/workflows/ci.yml:41`
- [#4](https://github.com/rubyatscale/bigrails-redis/security/code-scanning/4) `actions/missing-workflow-permissions` (medium) — `.github/workflows/triage.yml:9`
- [#2](https://github.com/rubyatscale/bigrails-redis/security/code-scanning/2) `actions/missing-workflow-permissions` (medium) — `.github/workflows/cd.yml:11`
- [#1](https://github.com/rubyatscale/bigrails-redis/security/code-scanning/1) `actions/missing-workflow-permissions` (medium) — `.github/workflows/stale.yml:8`

### Verification

- Every job in every flagged workflow now has an effective `permissions:` block (cross-checked by parsing the YAML against the alert list).
- `actionlint` output is byte-identical to `main` — no new findings introduced.
- `codeql.yml` untouched.
